### PR TITLE
Trim trailing newline characters by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2019-08-12
+### Added
+- Trailing newline character `\n` trimming enabled by default
+
 ## [1.0.0] - 2019-08-09
 ### Changes
 -  Initial version

--- a/configs.go
+++ b/configs.go
@@ -5,8 +5,17 @@ import "github.com/sirupsen/logrus"
 // Config holds the configuration to be used with WithConfig() configurer
 // This struct is useful to embed into configuration structs parsed with libraries like envconfig
 type Config struct {
-	Level  string        `default:"info"`
-	Fields logrus.Fields `default:"logger:stdlib"`
+	Level                   string        `default:"info"`
+	Fields                  logrus.Fields `default:"logger:stdlib"`
+	TrailingNewLineTrimming bool          `default:"true"`
+}
+
+// WithTrailingNewLineTrimming configures trailing newline trimming. This is true by default, because
+// log.Print adds a newline in the end of its messages, which does not make sense inside of a logrus log
+func WithTrailingNewLineTrimming(trim bool) Configurer {
+	return func(w *writer) {
+		w.trailingNewLineTrimming = trim
+	}
 }
 
 // WithLogger configures the logger with the one provided

--- a/configs_test.go
+++ b/configs_test.go
@@ -1,6 +1,7 @@
 package logrusiowriter
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -49,6 +50,75 @@ func TestWithConfig(t *testing.T) {
 
 		if providedErr == nil {
 			t.Errorf("Error provided to OnLevelParseError should not be nil")
+		}
+	})
+
+	t.Run("trimming", func(t *testing.T) {
+		const newLineAppendedByLogrus = "\n"
+		for _, tc := range []struct {
+			desc     string
+			trimming bool
+			input    string
+			expected string
+		}{
+			{
+				desc:     "zerolength with trimming",
+				trimming: true,
+				input:    "",
+				expected: "level=info" + newLineAppendedByLogrus,
+			},
+			{
+				desc:     "zerolength without trimming",
+				trimming: false,
+				input:    "",
+				expected: "level=info" + newLineAppendedByLogrus,
+			},
+			{
+				desc:     "only newline with trimming",
+				trimming: true,
+				input:    "\n",
+				expected: "level=info" + newLineAppendedByLogrus,
+			},
+			{
+				desc:     "only newline without trimming",
+				trimming: false,
+				input:    "\n",
+				expected: `level=info msg="\n"` + newLineAppendedByLogrus,
+			},
+			{
+				desc:     "with trailing newline and trimming",
+				trimming: true,
+				input:    "message\n",
+				expected: "level=info msg=message" + newLineAppendedByLogrus,
+			},
+			{
+				desc:     "with trailing newline and no trimming",
+				trimming: false,
+				input:    "message\n",
+				expected: `level=info msg="message\n"` + newLineAppendedByLogrus,
+			},
+			{
+				desc:     "no newline with trimming",
+				trimming: true,
+				input:    "message",
+				expected: "level=info msg=message" + newLineAppendedByLogrus,
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				buf := &bytes.Buffer{}
+
+				bufLogger := logrus.New()
+				bufLogger.SetOutput(buf)
+				bufLogger.Formatter.(*logrus.TextFormatter).DisableTimestamp = true
+
+				writer := New(WithLogger(bufLogger), WithTrailingNewLineTrimming(tc.trimming))
+
+				_, _ = writer.Write([]byte(tc.input))
+
+				if buf.String() != tc.expected {
+					t.Errorf("Unexpected output\nExpected: '%s'\nGot:      '%s'", tc.expected, buf.String())
+				}
+			})
 		}
 	})
 }

--- a/example_configs_test.go
+++ b/example_configs_test.go
@@ -79,6 +79,18 @@ func ExampleWithConfigInterface() {
 	// level=trace msg="Hello World!" config=interface
 }
 
+func ExampleWithNewLineTrimming() {
+	removeTimestampAndSetOutputToStdout(logrus.StandardLogger())
+
+	writer := logrusiowriter.New(
+		logrusiowriter.WithTrailingNewLineTrimming(true),
+	)
+
+	_, _ = fmt.Fprint(writer, "Hello World!\n")
+	// Output:
+	// level=info msg="Hello World!"
+}
+
 type configProvider struct{}
 
 func (configProvider) Level() logrus.Level { return logrus.TraceLevel }

--- a/example_writer_test.go
+++ b/example_writer_test.go
@@ -16,5 +16,5 @@ func ExampleNew() {
 	log.Printf("Standard log")
 
 	// Output:
-	// level=info msg="Standard log\n"
+	// level=info msg="Standard log"
 }


### PR DESCRIPTION
log.Print, which is the most likely user of this library, always appends
a trailing newline characters to what it prints. We don't want it to be
printed inside of the message field of logrus, so we trim it.